### PR TITLE
pass reconnect=1 to WebSocketApp.run_forever to enable auto-reconnects.

### DIFF
--- a/hyperliquid/websocket_manager.py
+++ b/hyperliquid/websocket_manager.py
@@ -50,9 +50,9 @@ class WebsocketManager(threading.Thread):
         self.ws = websocket.WebSocketApp(ws_url, on_message=self.on_message, on_open=self.on_open)
         self.ping_sender = threading.Thread(target=self.send_ping)
 
-    def run(self):
+    def run(self, reconnect: int=1):
         self.ping_sender.start()
-        self.ws.run_forever()
+        self.ws.run_forever(reconnect=1)
 
     def send_ping(self):
         while True:


### PR DESCRIPTION
default value for `WebSocketApp.run_forever` `reconnect` is `0`, thus if statement to reconnect won't go through.
![image](https://github.com/shusei-kagari/hyperliquid-python-sdk/assets/113465213/1c7f4076-d205-4c26-8344-5acf1528cfb4)
![image](https://github.com/shusei-kagari/hyperliquid-python-sdk/assets/113465213/d24cee51-d3de-44b9-944f-ec5e1a5f452a)

`WebSocketApp.run_forever`, internal fn `handle_disconnect`
![image](https://github.com/shusei-kagari/hyperliquid-python-sdk/assets/113465213/e300f191-57e0-42cf-a268-ca533f41d37a)

Unless this is intended behavior.